### PR TITLE
Switch from codepush to App Center CLI

### DIFF
--- a/src/utils/codepush.rs
+++ b/src/utils/codepush.rs
@@ -12,8 +12,8 @@ use serde_json;
 use utils::releases::{get_xcode_release_name, infer_gradle_release_name};
 use utils::xcode::{InfoPlist, XcodeProjectInfo};
 
-static CODEPUSH_BIN_PATH: &'static str = "code-push";
-static CODEPUSH_NPM_PATH: &'static str = "node_modules/.bin/code-push";
+static APPCENTER_BIN_PATH: &'static str = "appcenter";
+static APPCENTER_NPM_PATH: &'static str = "node_modules/.bin/appcenter";
 
 #[derive(Debug, Deserialize)]
 pub struct CodePushPackage {
@@ -44,29 +44,45 @@ fn get_codepush_error(output: process::Output) -> Error {
 }
 
 pub fn get_codepush_deployments(app: &str) -> Result<Vec<CodePushDeployment>, Error> {
-    let codepush_bin = if Path::new(CODEPUSH_NPM_PATH).exists() {
-        CODEPUSH_NPM_PATH
+    let appcenter_bin = if Path::new(APPCENTER_NPM_PATH).exists() {
+        APPCENTER_NPM_PATH
     } else {
-        CODEPUSH_BIN_PATH
+        APPCENTER_BIN_PATH
     };
 
-    let output = process::Command::new(codepush_bin)
+    let output = process::Command::new(appcenter_bin)
+        .arg("codepush")
         .arg("deployment")
-        .arg("ls")
+        .arg("list")
+        .arg("--app")
         .arg(app)
-        .arg("--format")
+        .arg("--output")
         .arg("json")
         .output()
         .map_err(|e| {
             if e.kind() == io::ErrorKind::NotFound {
-                "Codepush not found. Is it installed and configured on the PATH?".into()
+                "App Center CLI not found. Is it installed and configured on the PATH?".into()
             } else {
-                Error::from(e).context("Failed to run codepush")
+                Error::from(e).context("Failed to run appcenter")
             }
         })?;
 
     if output.status.success() {
-        Ok(serde_json::from_slice(&output.stdout)?)
+        let raw_data: Vec<Vec<String>> = serde_json::from_slice(&output.stdout)?;
+
+        let mapped: Vec<CodePushDeployment> = raw_data
+            .iter()
+            .map(|&ref pair| CodePushDeployment {
+                name: pair[0].clone(),
+                package: if let Some(lbl) = pair.get(1) {
+                    Some(CodePushPackage { label: lbl.clone() })
+                } else {
+                    None
+                },
+            })
+            .collect();
+
+        Ok(mapped)
     } else {
         Err(get_codepush_error(output)
             .context("Failed to get codepush deployments")


### PR DESCRIPTION
The `sentry-cli react-native codepush ...` command currently uses the `codepush` CLI, which is deprecated in favor of the App Center CLI. This PR moves over to the new App Center CLI.

The main difference is the output of the CLIs. App Center's output for `deployment list ...` is something like this:
```json
[["Staging", "123abc"], ["Release", "456def"]]
```
So I mapped that data into the array of structs that the old CodePush CLI outputted.

I'm not super familiar with Rust so if my code is ugly or not idiomatic let me know and I'll try to clean it up.